### PR TITLE
Change access to public for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,6 @@
     "react": "^16.11.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }


### PR DESCRIPTION
I did this manually from the cli for the last release but this should be automated.

https://github.com/semantic-release/semantic-release/blob/ef1b8a0b910b81070a600c8c772434ec345812dd/docs/support/FAQ.md#how-can-i-set-the-access-level-of-the-published-npm-package