### PR TITLE
fix(*): move apollo-related packages to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "@types/react": "^16.9.4",
     "@types/react-dom": "^16.9.4",
     "accepts": "^1.3.7",
-    "apollo-cache-inmemory": "^1.6.3",
-    "apollo-client": "^2.6.4",
     "bcp-47-match": "^1.0.1",
     "graphql": "^14.5.8",
     "hoist-non-react-statics": "^3.3.0",
@@ -71,6 +69,8 @@
     "@apollo/react-ssr": "3.1.3",
     "@types/hoist-non-react-statics": "3.3.1",
     "@typescript-eslint/parser": "2.19.0",
+    "apollo-cache-inmemory": "^1.6.3",
+    "apollo-client": "^2.6.4",
     "del-cli": "3.0.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.0",
@@ -83,6 +83,8 @@
     "semantic-release": "17.0.2"
   },
   "peerDependencies": {
+    "apollo-cache-inmemory": "^1.6.3",
+    "apollo-client": "^2.6.4",
     "next": "^9.1.4",
     "react": "^16.11.0"
   },


### PR DESCRIPTION
We want to ensure that a user of appWithApolloClient is able to supply their own version of apollo-client, rather than the latest compatible version declared by next-utils' "dependencies". This prevents type errors due to version mismatches.

Depends on https://github.com/Yolk-HQ/next-utils/pull/26

This is also a demonstration of using a semantic-release channel to publish a custom dist-tag prerelease to npm, for the purpose of testing this change in another repository. For example, see this build: https://github.com/Yolk-HQ/next-utils/runs/462815923

```
[7:17:50 AM] [semantic-release] › ✔  Published release 1.0.1-fix-peer-deps.1 on fix-peer-deps channel
```

Version `1.0.1-fix-peer-deps.1` can be tested in other codebases, without affecting the mainline releases on the `latest` dist-tag.